### PR TITLE
Fix missing header

### DIFF
--- a/core/requester.py
+++ b/core/requester.py
@@ -28,8 +28,10 @@ class Requester(object):
 
             # Parse headers
             content = content.split('\n')
-            for header in content[1:-2]:
-                name, value = header.split(': ')
+            for header in content[1:]:
+                name, _, value = header.partition(': ')
+                if not name or not value:
+                    continue
                 self.headers[name] = value
             self.host = self.headers['Host']
 


### PR DESCRIPTION
i just used ssrfmap to fuzz GET request that required user logged-in but fail at application level with lots of redirect response to login page. looks like `Cookie:` header is being left out because we only iterate until third element from last `content[1:-2]` [core/requester.py#L31](https://github.com/swisskyrepo/SSRFmap/blob/master/core/requester.py#L31)
example request like this
```
GET /accounts?from=/profile HTTP/1.1
Host: www.example.com
User-Agent: Mozilla/5.0
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
Accept-Language: en-US,en;q=0.5
Accept-Encoding: gzip, deflate
Referer: https://www.example.com/?from=/dashboard
Connection: close
Cookie: user_credentials=194448e044;
Upgrade-Insecure-Requests: 1
```
`self.headers` will only iterate until `Connection: close`
i added some fixes for this