### PR TITLE
Fix parse method and action uri

### DIFF
--- a/core/requester.py
+++ b/core/requester.py
@@ -22,12 +22,12 @@ class Requester(object):
             exit()
 
         try:
+            content = content.split('\n')
             # Parse method and action URI
             regex = re.compile('(.*) (.*) HTTP')
-            self.method, self.action = regex.findall(content)[0]
+            self.method, self.action = regex.findall(content[0])[0]
 
             # Parse headers
-            content = content.split('\n')
             for header in content[1:]:
                 name, _, value = header.partition(': ')
                 if not name or not value:


### PR DESCRIPTION
I just found minor issue when trying to fuzz a post request that contain huge data, example request like this

```
POST /products/upload?access_token=12345 HTTP/1.1
User-Agent: Mozilla/5.0
Accept-Encoding: gzip, deflate
Accept: application/json
Connection: close
Host: api.example.com
Accept-Language: en-US,en;q=0.5
Content-Type: application/json
Content-Length: 387661
Origin: https://www.example.com

{"product_image":"a-huge-base64-encoded-image"}
```
It takes forever when `findall` function executed [core/requester.py#L27](https://github.com/swisskyrepo/SSRFmap/blob/master/core/requester.py#L27)

I added some fixes for this