### PR TITLE
BUG/MINOR: requester: fix GET param replacement

### DIFF
--- a/core/requester.py
+++ b/core/requester.py
@@ -131,7 +131,7 @@ class Requester(object):
                         exit(1)  
             else:
                 # String is immutable, we don't have to do a "forced" copy
-                regex = re.compile(param+"=(\w+)")
+                regex = re.compile(param+"=([^&]+)")
                 value = urllib.parse.quote(value, safe='')
                 data_injected = re.sub(regex, param+'='+value, self.action)
                 r = requests.get(


### PR DESCRIPTION
The specified "param" value should be entirely replaced by the payload. This seems to work as expected when using POST values as it is entirely reset. However, the GET value is replaced using regex, which was not matching the entire value causing the original value to be appended to the payload. For example, assuming the following value request:

```
GET /?url=https%3A%2F%2Fgoogle.com
```

A sample payload from the readfile module would become:

```
file:///etc/passwd://google.com
```

This is mostly due to the existing regex using a word (\w) match, which prevents it from parsing "://" (%3A%2F%2F). Generally, query string params should be properly urlencoded so we should be able to replace anything after `param=` up until the default delimeter (&).

This is less of an issue if you just set the starting param to a string (the example in data/request3.txt uses SSRF. However, based on the provided example within the README, this may not be obvious to new users and having consistency between starting payloads could be helpful.

This commit switches the regex from a word match (\w) to a negated character class, matching everything up to the next ampersand (&).