### PR TITLE
MINOR: readfiles: check if output is ELF binary

### DIFF
--- a/modules/readfiles.py
+++ b/modules/readfiles.py
@@ -13,6 +13,7 @@ class exploit():
     def __init__(self, requester, args):
         logging.info(f"Module '{name}' launched !")
         self.files = args.targetfiles.split(',') if args.targetfiles != None else ["/etc/passwd", "/etc/lsb-release", "/etc/shadow", "/etc/hosts", "\/\/etc/passwd", "/proc/self/environ", "/proc/self/cmdline", "/proc/self/cwd/index.php", "/proc/self/cwd/application.py", "/proc/self/cwd/main.py", "/proc/self/exe"]   
+        self.file_magic = {'elf' : bytes([0x7f, 0x45, 0x4c, 0x46])}
         
         r = requester.do_request(args.param, "")
         
@@ -31,7 +32,10 @@ class exploit():
 
                     # Display diff between default and ssrf request
                     logging.info(f"\033[32mReading file\033[0m : {f}")
-                    print(diff)
+                    if bytes(diff, encoding='utf-8').startswith(self.file_magic["elf"]):
+                        print("ELF binary found - not printing to stdout")
+                    else:
+                        print(diff)
 
                     # Write diff to a file
                     filename = f.replace('\\','_').replace('/','_')


### PR DESCRIPTION
One of the checks for /proc/self/exe returns a binary directly to terminal, which could print a several MB file out and also can cause pain within a terminal due to a variety of escape sequences requiring a "reset" to be performed.

This commit adds a check for ELF magic bytes to determine whether the output is an ELF binary and if so it avoid writing it to stdout but still writes it a local file.

Sample output:
```
[INFO]:Reading file : /proc/self/exe
ELF binary found - not printing to stdout
[INFO]:Writing file : /proc/self/exe to 127.0.0.1/_proc_self_exe
```